### PR TITLE
Add option when parsing svg to force Z

### DIFF
--- a/src/addSVG.js
+++ b/src/addSVG.js
@@ -14,11 +14,12 @@ export async function addSVG(
     yShift = 0,
     mirrorY = true,
     disableCut = true,
+    forceZ = false,
   }
 ) {
   const face = shape.faces[faceIndex];
 
-  let image = drawSVG(svgString, { width });
+  let image = drawSVG(svgString, { width, forceZ });
   const imgCenter = image.boundingBox.center;
 
   image = image.translate(-imgCenter[0], -imgCenter[1]);

--- a/src/parseSVG.js
+++ b/src/parseSVG.js
@@ -8,7 +8,7 @@ import {
   ellipseBlueprint,
 } from "./svgShapes";
 
-export function drawSVG(svg, { width } = {}) {
+export function drawSVG(svg, { width, forceZ } = {}) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(svg, "text/html");
 
@@ -16,7 +16,7 @@ export function drawSVG(svg, { width } = {}) {
 
   for (let path of Array.from(doc.getElementsByTagName("path"))) {
     let commands = path.getAttribute("d");
-    const pathBlueprints = Array.from(SVGPathBlueprint(commands));
+    const pathBlueprints = Array.from(SVGPathBlueprint(commands, forceZ));
     blueprints.push(...pathBlueprints);
   }
 

--- a/src/svgShapes.js
+++ b/src/svgShapes.js
@@ -156,7 +156,7 @@ const parseArgs = (command, previousPoint, previousControls) => {
   }
 };
 
-export const SVGPathBlueprint = function* (SVGPath) {
+export const SVGPathBlueprint = function* (SVGPath, forceZ) {
   const commands = absolutize(parsePath(SVGPath));
 
   let sk = null;
@@ -179,7 +179,11 @@ export const SVGPathBlueprint = function* (SVGPath) {
 
     if (command.key === "M") {
       if (sk) {
-        yield sk.done();
+        if (forceZ) {
+          yield sk.close();
+        } else {
+          yield sk.done();
+        }
       }
 
       sk = new BlueprintSketcher(p);
@@ -218,5 +222,11 @@ export const SVGPathBlueprint = function* (SVGPath) {
     lastControls = { control1, control2 };
   }
 
-  if (sk) yield sk.done();
+  if (sk) {
+    if (forceZ) {
+      yield sk.close();
+    } else {
+      yield sk.done();
+    }
+  }
 };


### PR DESCRIPTION
When parsing some svgs to stl, I've found that some svgs that render correctly give a warning about non-manifold edges when converted to stls. The fix is to usually add a Z to the start of each M. This PR adds an option to force this without having to edit the svg