### PR TITLE
Add `firstPointPrecision` option to drawSVG

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,13 @@
 import { GCWithScope, getOC, drawFaceOutline } from "replicad";
 
+export const samePoint = (
+  [x0, y0],
+  [x1, y1],
+  precision = 1e-6
+) => {
+  return Math.abs(x0 - x1) <= precision && Math.abs(y0 - y1) <= precision;
+};
+
 export const range = (size) => [...Array(size).keys()];
 
 export const mergeDrawings = (drawings) => {

--- a/src/parseSVG.js
+++ b/src/parseSVG.js
@@ -8,7 +8,7 @@ import {
   ellipseBlueprint,
 } from "./svgShapes";
 
-export function drawSVG(svg, { width, alwaysClosePaths = false } = {}) {
+export function drawSVG(svg, { width, alwaysClosePaths = false, firstPointPrecision = null } = {}) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(svg, "text/html");
 
@@ -17,7 +17,7 @@ export function drawSVG(svg, { width, alwaysClosePaths = false } = {}) {
   for (let path of Array.from(doc.getElementsByTagName("path"))) {
     let commands = path.getAttribute("d");
     const pathBlueprints = Array.from(
-      SVGPathBlueprint(commands, alwaysClosePaths)
+      SVGPathBlueprint(commands, alwaysClosePaths, firstPointPrecision)
     );
     blueprints.push(...pathBlueprints);
   }

--- a/src/svgShapes.js
+++ b/src/svgShapes.js
@@ -1,5 +1,6 @@
 import { BlueprintSketcher } from "replicad";
 import { parsePath, absolutize } from "path-data-parser";
+import { samePoint } from "./common";
 
 export const roundedRectangleBlueprint = ({
   x = 0,
@@ -163,7 +164,7 @@ const parseArgs = (command, previousPoint, previousControls) => {
   throw new Error(`Unknown command ${command.key} ${command.data.join(", ")}`);
 };
 
-export const SVGPathBlueprint = function* (SVGPath, alwaysClosePaths) {
+export const SVGPathBlueprint = function* (SVGPath, alwaysClosePaths, firstPointPrecision) {
   const commands = absolutize(parsePath(SVGPath));
 
   let sk = null;
@@ -184,6 +185,10 @@ export const SVGPathBlueprint = function* (SVGPath, alwaysClosePaths) {
       arcConfig = [],
     } = parseArgs(command, lastPoint, lastControls);
 
+    if (firstPointPrecision && sk && samePoint(sk.firstPoint, p, firstPointPrecision)) {
+      p.splice(0, p.length, ...sk.firstPoint);
+    }
+
     if (command.key === "M") {
       if (sk) {
         if (alwaysClosePaths) {
@@ -201,8 +206,7 @@ export const SVGPathBlueprint = function* (SVGPath, alwaysClosePaths) {
     // We do not draw line of length 0
     if (
       lastPoint &&
-      Math.abs(p[0] - lastPoint[0]) < 1e-9 &&
-      Math.abs(p[1] - lastPoint[1]) < 1e-9
+      samePoint(p, lastPoint, 1e-9)
     ) {
       lastPoint = p;
       lastControls = { control1, control2 };


### PR DESCRIPTION
An alternative PR for https://github.com/sgenoud/replicad/pull/250

Potentially fixes issues with SVGs where lines cross due to loss of precision (as show below)
<img width="1004" height="156" alt="Screenshot 2025-12-24 at 16 06 04" src="https://github.com/user-attachments/assets/49781669-8b97-42c4-866d-1feddd54f369" />

SVGs seem fine with this but this causes non-manifold errors when exporting.